### PR TITLE
Added "Modular" to hero text

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -60,7 +60,7 @@
         Architecture and Mediator pattern with <button
             class="select-text text-inverse underline"
             on:click={() => scrollIntoView(examplesDiv)}>no boilerplate</button
-        >.<br />Extensible. Fast. Source Generated. Open Source.
+        >.<br />Extensible. Modular. Fast. Source Generated. Open Source.
     </p>
 
     <div class="flex gap-4">


### PR DESCRIPTION
The hero text on the home page now contains the word "Modular", this is to communicate to the users that Immediate.Platform is not a framework and is instead a composition of different opt-in packages.