### PR TITLE
Added cookbook page for publish-subscribe pattern

### DIFF
--- a/src/routes/docs/[...6]cookbook/[...7]pub-sub/+page.md
+++ b/src/routes/docs/[...6]cookbook/[...7]pub-sub/+page.md
@@ -13,8 +13,7 @@ Immediate.Handlers fully supports this pattern, but it intentionally does not pr
 abstraction. Maintaining an opinionated publish-subscribe implementation is out of scope and would limit
 the flexibility required by different projects.
 
-To save you time, the example below is the implementation that is typically recommended when you need simple
-publish-subscribe behavior.
+An example is provided here of a simple `Publisher` which works for many cases.
 
 ```cs
 public sealed class Publisher<TNotification>(
@@ -33,5 +32,5 @@ public sealed class Publisher<TNotification>(
 
 Finally, this implementation can simply be registered as singleton service:
 ```cs
-services.AddSingleton<Publisher<>>();
+services.AddSingleton(typeof(Publisher<>));
 ```

--- a/src/routes/docs/[...6]cookbook/[...7]pub-sub/+page.md
+++ b/src/routes/docs/[...6]cookbook/[...7]pub-sub/+page.md
@@ -1,0 +1,37 @@
+---
+title: Publish-Subscribe pattern
+description: Cookbook example showing how to implement the publish-subscribe pattern
+---
+
+# {$frontmatter.title}
+
+If you are coming from other popular mediator libraries, you may be looking for a way to implement the
+[publish-subscribe pattern](https://learn.microsoft.com/en-us/azure/architecture/patterns/publisher-subscriber)
+with Immediate.Handlers. A common use case is implementing domain events.
+
+Immediate.Handlers fully supports this pattern, but it intentionally does not provide a built-in `Publisher`
+abstraction. Maintaining an opinionated publish-subscribe implementation is out of scope and would limit
+the flexibility required by different projects.
+
+To save you time, the example below is the implementation that is typically recommended when you need simple
+publish-subscribe behavior.
+
+```cs
+public sealed class Publisher<TNotification>(
+    IServiceProvider serviceProvider
+)
+{
+    public async ValueTask Publish(TNotification notification)
+    {
+        foreach (var handler in serviceProvider.GetServices<IHandler<TNotification, ValueTuple>>())
+        {
+            await handler.Handle(notification);
+        }
+    }
+}
+````
+
+Finally, this implementation can simply be registered as singleton service:
+```cs
+services.AddSingleton<Publisher<>>();W
+```

--- a/src/routes/docs/[...6]cookbook/[...7]pub-sub/+page.md
+++ b/src/routes/docs/[...6]cookbook/[...7]pub-sub/+page.md
@@ -33,5 +33,5 @@ public sealed class Publisher<TNotification>(
 
 Finally, this implementation can simply be registered as singleton service:
 ```cs
-services.AddSingleton<Publisher<>>();W
+services.AddSingleton<Publisher<>>();
 ```

--- a/src/routes/docs/[...6]cookbook/[...7]pub-sub/+page.md
+++ b/src/routes/docs/[...6]cookbook/[...7]pub-sub/+page.md
@@ -28,7 +28,7 @@ public sealed class Publisher<TNotification>(
         }
     }
 }
-````
+```
 
 Finally, this implementation can simply be registered as singleton service:
 ```cs


### PR DESCRIPTION
This PR adds a page to the documentation. It adds a cookbook page that explains how to use the publish-subscribe pattern with Immediate.Handlers. 

Code was gathered directly from Viceroy. 