### PR TITLE
Update handler registration in quickstart guide

### DIFF
--- a/src/routes/docs/[...1]getting-started/[...2]quickstart/+page.md
+++ b/src/routes/docs/[...1]getting-started/[...2]quickstart/+page.md
@@ -33,7 +33,8 @@ dotnet add package Immediate.Cache
 
 ```cs |copy|title=Program.cs {2}
 var builder = WebApplication.CreateBuilder();
-builder.Services.AddHandlers();
+// <MyApp> here will be the name of your project
+builder.Services.AddMyAppHandlers();
 
 var app = builder.Build();
 app.Run();

--- a/src/routes/docs/[...1]getting-started/[...2]quickstart/+page.md
+++ b/src/routes/docs/[...1]getting-started/[...2]quickstart/+page.md
@@ -33,7 +33,7 @@ dotnet add package Immediate.Cache
 
 ```cs |copy|title=Program.cs {2}
 var builder = WebApplication.CreateBuilder();
-// <MyApp> here will be the name of your project
+
 builder.Services.AddMyAppHandlers();
 
 var app = builder.Build();
@@ -88,6 +88,7 @@ First modify your `Program.cs` to register the Immediate.Apis endpoints, like so
 
 ```cs |copy|title=Program.cs {5-6}
 var builder = WebApplication.CreateBuilder();
+
 builder.Services.AddMyAppHandlers();
 
 var app = builder.Build();


### PR DESCRIPTION
I stumbled on this following the quickstart guide. 

In the 'Turn your handler into an endpoint' step, the correct snippet was available, so I added it with the explanatory comment.